### PR TITLE
Deteted the \ character before the comment, preventing a SyntaxError

### DIFF
--- a/src/python/MLaaS4HEP/ex_keras.py
+++ b/src/python/MLaaS4HEP/ex_keras.py
@@ -14,6 +14,6 @@ def model(idim):
         Activation('softmax'),
     ])
     ml_model.compile(optimizer='adam', \
-                  loss='categorical_crossentropy', \ # use loss='binary_crossentropy' if you have 2 output classes
+                  loss='categorical_crossentropy',  # use loss='binary_crossentropy' if you have 2 output classes
                   metrics=['accuracy'])
     return ml_model


### PR DESCRIPTION
The following error appears if I leave the '\' character before '#':
SyntaxError: unexpected character after line continuation character
