### PR TITLE
Fixed wrong nevts value passed as argument. Not equal to 0 but equal to self.evts

### DIFF
--- a/src/python/MLaaS4HEP/generator.py
+++ b/src/python/MLaaS4HEP/generator.py
@@ -245,7 +245,7 @@ class RootDataGenerator(object):
 
             reader = RootDataReader(fname, branch=branch, identifier=identifier,\
                     selected_branches=branches, exclude_branches=exclude_branches, \
-                    nan=nan, chunk_size=chunk_size, nevts=0, specs=specs, \
+                    nan=nan, chunk_size=chunk_size, nevts=self.evts, specs=specs, \
                     redirector=redirector, verbose=verbose)
 
             if not os.path.isfile(sname):


### PR DESCRIPTION
Wrong value passed to nevts parameter. This issue was the cause of the continuous printing of the line "will use 2000 events to obtain dimensionality" using nevts=n, where n is a number different to 0 or -1.