### PR TITLE
reset specs value and other stuff

### DIFF
--- a/src/python/MLaaS4HEP/generator.py
+++ b/src/python/MLaaS4HEP/generator.py
@@ -253,6 +253,9 @@ class RootDataGenerator(object):
                     print("writing specs {}".format(sname))
                 reader.write_specs(sname)
 
+            if not specs:
+                reader.load_specs(sname)
+
             self.reader[fname] = reader
             self.reader_counter[fname] = 0
             specs={}
@@ -283,7 +286,6 @@ class RootDataGenerator(object):
                 .format(self.start_idx, self.stop_idx-1, self.current_file, \
                 self.file_label_dict[self.current_file])
         gen = self.read_data(self.start_idx, self.stop_idx)
-        # advance start and stop indecies
         if self.verbose:
             print(msg)
         data = []
@@ -337,6 +339,7 @@ class RootDataGenerator(object):
             read_evts = stop-start
         # update how many events we read from current file
         self.reader_counter[self.current_file] += read_evts
+        # advance start and stop indecies
         self.start_idx = stop
         self.stop_idx = self.start_idx + self.chunk_size
         if self.verbose:

--- a/src/python/MLaaS4HEP/generator.py
+++ b/src/python/MLaaS4HEP/generator.py
@@ -253,14 +253,11 @@ class RootDataGenerator(object):
                     print("writing specs {}".format(sname))
                 reader.write_specs(sname)
 
-            if not specs:
-                reader.load_specs(sname)
-
             self.reader[fname] = reader
             self.reader_counter[fname] = 0
+            specs={}
 
         self.current_file = self.files[0]
-
         print("init RootDataGenerator in {} sec".format(time.time()-time0))
 
     @property
@@ -283,7 +280,7 @@ class RootDataGenerator(object):
             idx = random.randint(0, len(self.files)-1)
             self.current_file = self.files[idx]
         msg = "\nread chunk [{}:{}] from {} label {}"\
-                .format(self.start_idx, self.stop_idx, self.current_file, \
+                .format(self.start_idx, self.stop_idx-1, self.current_file, \
                 self.file_label_dict[self.current_file])
         gen = self.read_data(self.start_idx, self.stop_idx)
         # advance start and stop indecies
@@ -320,7 +317,7 @@ class RootDataGenerator(object):
                 self.current_file = self.files[0]
                 if self.verbose:
                     msg = "\nread chunk [{}:{}] from {} label {}"\
-                        .format(self.start_idx, self.stop_idx, self.current_file, \
+                        .format(self.start_idx, self.stop_idx-1, self.current_file, \
                         self.file_label_dict[self.current_file])
                     print(msg)
             else:

--- a/src/python/MLaaS4HEP/models.py
+++ b/src/python/MLaaS4HEP/models.py
@@ -120,7 +120,6 @@ def train_model(model, files, labels, preproc=None, params=None, specs=None, fou
             print("x_mask chunk of {} shape".format(np.shape(x_mask)))
         print("x_train chunk of {} shape".format(np.shape(x_train)))
         print("y_train chunk of {} shape".format(np.shape(y_train)))
-        print("y_train chunk of {} shape".format(np.shape(y_train)))
         if np.shape(x_train)[0] == 0:
             print("received empty x_train chunk")
             break


### PR DESCRIPTION
Reset specs after the reading of a file because otherwise when you run two times workflow, the second time the specs is always equal to the specs of the first file of the list of files provided. Changed also other little stuff